### PR TITLE
Add peak annotation format schema

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,6 @@
 name: Python tests
 
-on: [push, pull_request]
+on: push
 
 jobs:
   test:

--- a/.github/workflows/validate-json-schemas.yml
+++ b/.github/workflows/validate-json-schemas.yml
@@ -1,6 +1,6 @@
 name: Validate JSON Schemas
 
-on: [push, pull_request]
+on: push
 
 jobs:
   validate:
@@ -21,7 +21,7 @@ jobs:
     - name: Validate peak annotation schema
       run: |
         jsonschema -i specification/peak-annotation-format/annotation-schema.json schema-draft-07.json
-    - name: Validate peak annotationn
+    - name: Validate peak annotation examples
       run: |
         jsonschema \
            -i specification/peak-annotation-format/annotation-example-1.json \

--- a/.github/workflows/validate-json-schemas.yml
+++ b/.github/workflows/validate-json-schemas.yml
@@ -1,0 +1,31 @@
+name: Validate JSON Schemas
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install jsonschema==3.2.0
+    - name: Get JSON Schema schema
+      run: |
+        curl http://json-schema.org/draft-07/schema# -o schema-draft-07.json
+    - name: Validate peak annotation schema
+      run: |
+        jsonschema -i specification/peak-annotation-format/annotation-schema.json schema-draft-07.json
+    - name: Validate peak annotationn
+      run: |
+        jsonschema \
+           -i specification/peak-annotation-format/annotation-example-1.json \
+           -i specification/peak-annotation-format/annotation-example-2.json \
+           -i specification/peak-annotation-format/annotation-example-3.json \
+           -i specification/peak-annotation-format/annotation-example-4.json \
+           specification/peak-annotation-format/annotation-schema.json

--- a/.github/workflows/validate-json-schemas.yml
+++ b/.github/workflows/validate-json-schemas.yml
@@ -20,12 +20,13 @@ jobs:
         curl http://json-schema.org/draft-07/schema# -o schema-draft-07.json
     - name: Validate peak annotation schema
       run: |
-        jsonschema -i specification/peak-annotation-format/annotation-schema.json schema-draft-07.json
+        jsonschema \
+           -i specification/peak-annotation-format/annotation-schema.json \
+           schema-draft-07.json
     - name: Validate peak annotation examples
       run: |
         jsonschema \
            -i specification/peak-annotation-format/annotation-example-1.json \
            -i specification/peak-annotation-format/annotation-example-2.json \
            -i specification/peak-annotation-format/annotation-example-3.json \
-           -i specification/peak-annotation-format/annotation-example-4.json \
            specification/peak-annotation-format/annotation-schema.json

--- a/specification/peak-annotation-format/annotation-example-1.json
+++ b/specification/peak-annotation-format/annotation-example-1.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/master/specification/peak-annotation-format/annotation-schema.json",
     "adducts": ["M+NH4"],
     "analyte_reference": 1,
     "charge": 2,

--- a/specification/peak-annotation-format/annotation-example-1.json
+++ b/specification/peak-annotation-format/annotation-example-1.json
@@ -1,0 +1,18 @@
+{
+    "adduct": ["+NH4"],
+    "analyte_reference": 1,
+    "charge": 2,
+    "confidence": 0.5,
+    "isotope": 1,
+    "mass_error": {
+        "value": -0.2,
+        "unit": "ppm"
+    },
+    "molecule_description": {
+        "position": 7,
+        "series": "y",
+        "series_label": "peptide"
+    },
+    "neutral_loss": ["-H2O"],
+    "rest": null
+}

--- a/specification/peak-annotation-format/annotation-example-1.json
+++ b/specification/peak-annotation-format/annotation-example-1.json
@@ -1,5 +1,6 @@
 {
-    "adduct": ["+NH4"],
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "adducts": ["M+NH4"],
     "analyte_reference": 1,
     "charge": 2,
     "confidence": 0.5,
@@ -13,6 +14,5 @@
         "series": "y",
         "series_label": "peptide"
     },
-    "neutral_loss": ["-H2O"],
-    "rest": null
+    "neutral_losses": ["-H2O"]
 }

--- a/specification/peak-annotation-format/annotation-example-2.json
+++ b/specification/peak-annotation-format/annotation-example-2.json
@@ -1,0 +1,18 @@
+{
+    "neutral_loss": ["-H2O"],
+    "isotope": 0,
+    "adduct": [],
+    "charge": 1,
+    "analyte_reference": 1,
+    "mass_error": {
+      "value": 14.4,
+      "unit": "ppm"
+    },
+    "confidence": null,
+    "rest": null,
+    "molecule_description": {
+      "series_label": "internal",
+      "start_position": 5,
+      "end_position": 8
+    }
+  }

--- a/specification/peak-annotation-format/annotation-example-2.json
+++ b/specification/peak-annotation-format/annotation-example-2.json
@@ -1,18 +1,18 @@
 {
-    "neutral_loss": ["-H2O"],
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "neutral_losses": ["-H2O"],
     "isotope": 0,
-    "adduct": [],
+    "adducts": [],
     "charge": 1,
     "analyte_reference": 1,
     "mass_error": {
-      "value": 14.4,
-      "unit": "ppm"
+        "value": 14.4,
+        "unit": "ppm"
     },
     "confidence": null,
-    "rest": null,
     "molecule_description": {
-      "series_label": "internal",
-      "start_position": 5,
-      "end_position": 8
+        "series_label": "internal",
+        "start_position": 5,
+        "end_position": 8
     }
   }

--- a/specification/peak-annotation-format/annotation-example-2.json
+++ b/specification/peak-annotation-format/annotation-example-2.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/master/specification/peak-annotation-format/annotation-schema.json",
     "neutral_losses": ["-H2O"],
     "isotope": 0,
     "adducts": [],

--- a/specification/peak-annotation-format/annotation-example-3.json
+++ b/specification/peak-annotation-format/annotation-example-3.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/master/specification/peak-annotation-format/annotation-schema.json",
     "neutral_losses": [],
     "isotope": 0,
     "adducts": [],

--- a/specification/peak-annotation-format/annotation-example-3.json
+++ b/specification/peak-annotation-format/annotation-example-3.json
@@ -1,0 +1,16 @@
+{
+    "neutral_loss": [],
+    "isotope": 0,
+    "adduct": [],
+    "charge": 1,
+    "analyte_reference": 1,
+    "mass_error": {
+        "value": -1.7,
+        "unit": "ppm"
+    },
+    "confidence": null,
+    "rest": null,
+    "molecule_description": {
+        "series_label": "precursor"
+    }
+}

--- a/specification/peak-annotation-format/annotation-example-3.json
+++ b/specification/peak-annotation-format/annotation-example-3.json
@@ -1,7 +1,8 @@
 {
-    "neutral_loss": [],
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "neutral_losses": [],
     "isotope": 0,
-    "adduct": [],
+    "adducts": [],
     "charge": 1,
     "analyte_reference": 1,
     "mass_error": {
@@ -9,7 +10,6 @@
         "unit": "ppm"
     },
     "confidence": null,
-    "rest": null,
     "molecule_description": {
         "series_label": "precursor"
     }

--- a/specification/peak-annotation-format/annotation-example-4.json
+++ b/specification/peak-annotation-format/annotation-example-4.json
@@ -1,0 +1,6 @@
+{
+    "analyte_reference": 1,
+    "molecule_description": {
+        "series_label": "unannotated"
+    }
+}

--- a/specification/peak-annotation-format/annotation-example-4.json
+++ b/specification/peak-annotation-format/annotation-example-4.json
@@ -1,6 +1,4 @@
 {
-    "analyte_reference": 1,
-    "molecule_description": {
-        "series_label": "unannotated"
-    }
+    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
+    "analyte_reference": 1
 }

--- a/specification/peak-annotation-format/annotation-example-4.json
+++ b/specification/peak-annotation-format/annotation-example-4.json
@@ -1,4 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/HUPO-PSI/mzSpecLib/feature/add-annotation-schema/specification/peak-annotation-format/annotation-schema.json",
-    "analyte_reference": 1
-}

--- a/specification/peak-annotation-format/annotation-schema.json
+++ b/specification/peak-annotation-format/annotation-schema.json
@@ -3,12 +3,13 @@
     "title": "HUPO-PSI Peak annotation specification",
     "description": "Annotation of an individual peak in a mass spectrum.",
     "type": "object",
-    "additionalProperties": false,
+    "additionalProperties": true,
     "required": ["analyte_reference", "molecule_description"],
     "properties": {
         "analyte_reference": {
             "description": "Label of analyte to which this annotation belongs",
-            "oneOf": [{"type": "string"}, {"type": "integer"}]
+            "oneOf": [{"type": "string"}, {"type": "integer"}],
+            "default": "1"
         },
         "molecule_description": {
             "description": "Description of the molecule or molecule fragment that this peak is annotated with",
@@ -23,7 +24,7 @@
                 {"$ref": "#/definitions/formula"}
             ]
         },
-        "neutral_loss": {
+        "neutral_losses": {
             "description": "Any additional gains or losses of chemical groups defined by formula or by name; multiple may be specified",
             "type": "array",
             "items": {
@@ -36,7 +37,7 @@
             "type": "number",
             "default": 0
         },
-        "adduct": {
+        "adducts": {
             "description": "The charge carrier(s) for the given annotation",
             "type": "array",
             "items": {
@@ -62,7 +63,7 @@
                 "unit": {
                     "description": "Mass error unit",
                     "type": "string",
-                    "enum": ["Da", "ppm"]
+                    "enum": ["ppm", "Da"]
                 }
             }
         },
@@ -70,9 +71,6 @@
             "description": "Number defining confidence in peak annotation",
             "oneOf": [{"type": "number"}, {"type": "null"}],
             "default": null
-        },
-        "rest": {
-            "description": "Optional field for custom use"
         }
     },
     "definitions": {
@@ -148,7 +146,7 @@
                     "enum": ["immonium"]
                 },
                 "amino_acid": {
-                    "description": "The amino acid represented by this immonium ion",
+                    "description": "One-letter code of the amino acid represented by this immonium ion",
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 1

--- a/specification/peak-annotation-format/annotation-schema.json
+++ b/specification/peak-annotation-format/annotation-schema.json
@@ -4,7 +4,7 @@
     "description": "Annotation of an individual peak in a mass spectrum.",
     "type": "object",
     "additionalProperties": true,
-    "required": ["analyte_reference", "molecule_description"],
+    "required": ["analyte_reference"],
     "properties": {
         "analyte_reference": {
             "description": "Label of analyte to which this annotation belongs",
@@ -21,8 +21,7 @@
                 {"$ref": "#/definitions/immonium"},
                 {"$ref": "#/definitions/reporter"},
                 {"$ref": "#/definitions/external"},
-                {"$ref": "#/definitions/formula"},
-                {"$ref": "#/definitions/unannotated"}
+                {"$ref": "#/definitions/formula"}
             ]
         },
         "neutral_losses": {
@@ -203,18 +202,6 @@
                 "formula": {
                     "description": "The elemental formula of the ion being marked",
                     "type": "string"
-                }
-            }
-        },
-        "unannotated": {
-            "description": "Unannotated peak",
-            "type": "object",
-            "required": ["series_label"],
-            "additionalProperties": false,
-            "properties": {
-                "series_label": {
-                    "$ref": "#/definitions/series_label",
-                    "enum": ["unannotated"]
                 }
             }
         }

--- a/specification/peak-annotation-format/annotation-schema.json
+++ b/specification/peak-annotation-format/annotation-schema.json
@@ -21,7 +21,8 @@
                 {"$ref": "#/definitions/immonium"},
                 {"$ref": "#/definitions/reporter"},
                 {"$ref": "#/definitions/external"},
-                {"$ref": "#/definitions/formula"}
+                {"$ref": "#/definitions/formula"},
+                {"$ref": "#/definitions/unannotated"}
             ]
         },
         "neutral_losses": {
@@ -77,7 +78,7 @@
         "series_label": {
             "description": "Type of ion being described, specifies the required molecule description keys",
             "type": "string",
-            "enum": ["peptide", "internal", "precursor", "immonium", "reporter", "external", "formula"]
+            "enum": ["peptide", "internal", "precursor", "immonium", "reporter", "external", "formula", "unannotated"]
         },
         "peptide": {
             "description": "Canonical peptide fragment ion",
@@ -202,6 +203,18 @@
                 "formula": {
                     "description": "The elemental formula of the ion being marked",
                     "type": "string"
+                }
+            }
+        },
+        "unannotated": {
+            "description": "Unannotated peak",
+            "type": "object",
+            "required": ["series_label"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["unannotated"]
                 }
             }
         }

--- a/specification/peak-annotation-format/annotation-schema.json
+++ b/specification/peak-annotation-format/annotation-schema.json
@@ -1,0 +1,211 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "HUPO-PSI Peak annotation specification",
+    "description": "Annotation of an individual peak in a mass spectrum.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["analyte_reference", "molecule_description"],
+    "properties": {
+        "analyte_reference": {
+            "description": "Label of analyte to which this annotation belongs",
+            "oneOf": [{"type": "string"}, {"type": "integer"}]
+        },
+        "molecule_description": {
+            "description": "Description of the molecule or molecule fragment that this peak is annotated with",
+            "type": "object",
+            "oneOf": [
+                {"$ref": "#/definitions/peptide"},
+                {"$ref": "#/definitions/internal"},
+                {"$ref": "#/definitions/precursor"},
+                {"$ref": "#/definitions/immonium"},
+                {"$ref": "#/definitions/reporter"},
+                {"$ref": "#/definitions/external"},
+                {"$ref": "#/definitions/formula"}
+            ]
+        },
+        "neutral_loss": {
+            "description": "Any additional gains or losses of chemical groups defined by formula or by name; multiple may be specified",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
+        },
+        "isotope": {
+            "description": "An isotopic peak offset from the monoisotopic peak",
+            "type": "number",
+            "default": 0
+        },
+        "adduct": {
+            "description": "The charge carrier(s) for the given annotation",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
+        },
+        "charge": {
+            "description": "The charge state of the ion generating this peak; this value is unsigned",
+            "type": "integer",
+            "minimum": 1,
+            "default": 1
+        },
+        "mass_error": {
+            "description": "Error between observed and theoretical mass",
+            "type": "object",
+            "required": ["value", "unit"],
+            "properties": {
+                "value": {
+                    "description": "Mass error value",
+                    "type": "number"
+                },
+                "unit": {
+                    "description": "Mass error unit",
+                    "type": "string",
+                    "enum": ["Da", "ppm"]
+                }
+            }
+        },
+        "confidence": {
+            "description": "Number defining confidence in peak annotation",
+            "oneOf": [{"type": "number"}, {"type": "null"}],
+            "default": null
+        },
+        "rest": {
+            "description": "Optional field for custom use"
+        }
+    },
+    "definitions": {
+        "series_label": {
+            "description": "Type of ion being described, specifies the required molecule description keys",
+            "type": "string",
+            "enum": ["peptide", "internal", "precursor", "immonium", "reporter", "external", "formula"]
+        },
+        "peptide": {
+            "description": "Canonical peptide fragment ion",
+            "type": "object",
+            "required": ["series_label", "series", "position"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["peptide"]
+                },
+                "series": {
+                    "description": "The peptide ion series this ion belongs to",
+                    "type": "string",
+                    "enum": ["b", "y", "a", "x", "c", "z"]
+                },
+                "position": {
+                    "description": "The position from the appropriate terminal along the peptide this ion was fragmented at (starting with 1)",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "internal": {
+            "description": "Internal fragment ion",
+            "type": "object",
+            "required": ["series_label", "start_position", "end_position"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["internal"]
+                },
+                "start_position": {
+                    "description": "N-terminal amino acid residue of the fragment in the original peptide sequence (beginning with 1, counting from the N-terminus)",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "end_position": {
+                    "description": "C-terminal amino acid residue of the fragment in the original peptide sequence (beginning with 1, counting from the N-terminus)",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "precursor": {
+            "description": "Precursor ion",
+            "type": "object",
+            "required": ["series_label"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["precursor"]
+                }
+            }
+        },
+        "immonium": {
+            "description": "Immonium ion",
+            "type": "object",
+            "required": ["series_label", "amino_acid", "modification"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["immonium"]
+                },
+                "amino_acid": {
+                    "description": "The amino acid represented by this immonium ion",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1
+                },
+                "modification": {
+                    "description": "An optional modification that may be attached to this immonium ion",
+                    "type": "string"
+                }
+            }
+        },
+        "reporter": {
+            "description": "Reporter ion",
+            "type": "object",
+            "required": ["series_label", "reporter_label"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["reporter"]
+                },
+                "reporter_label": {
+                    "description": "The labeling reagent's name or channel information",
+                    "type": "string"
+                }
+            }
+        },
+        "external": {
+            "description": "External ion",
+            "type": "object",
+            "required": ["series_label", "external_label"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["external"]
+                },
+                "external_label": {
+                    "description": "The name of the external ion being marked",
+                    "type": "string"
+                }
+            }
+        },
+        "formula": {
+            "description": "Ion described by chemical formula",
+            "type": "object",
+            "required": ["series_label", "formula"],
+            "additionalProperties": false,
+            "properties": {
+                "series_label": {
+                    "$ref": "#/definitions/series_label",
+                    "enum": ["formula"]
+                },
+                "formula": {
+                    "description": "The elemental formula of the ion being marked",
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
JSON Schema version of the [peak annotation format data model](https://docs.google.com/document/d/1yEUNG4Ump6vnbMDs4iV4s3XISflmOkRAyqUuutcCG2w/edit#) by @mobiusklein. Some notes and questions:

1. `amino_acid` -> Limit to one-letter-code only?
2. `neutral_loss` and `adduct` should be empty lists (`[]`) instead of `null`?
3. `analyte_reference` also as required property?
4. `adduct` -> Should it be `adducts`, as it is a list?
5. `mass_error` as required property? If there is an annotation, it should be possible to calculate the mass error... Also not possible to define default value (although this could be `null`).
6. `mass_error` `unit` -> Is `"enum": ["ppm", "Da"]` (all possible values) too limiting? E.g., this is case-sensitive... Is `u` sometimes used instead of `Da`?
6. `rest` -> Should this be limited to strings only, or could this be a full json object? In the text serialization, this is probably limited to one flat line of text.
7. I added some more descriptions compared to the Google Doc. We should add them there when this is approved.
