### PR TITLE
Fix isobaric labels JSON

### DIFF
--- a/specification/IsobaricLabelIons.json
+++ b/specification/IsobaricLabelIons.json
@@ -1,4 +1,4 @@
-Isobaric_label_ions = {
+"Isobaric_label_ions" = {
   "TMT126" : {
     "label_type" : "TMT",
     "ion_type"   : "reporter",

--- a/specification/IsobaricLabelIons.json
+++ b/specification/IsobaricLabelIons.json
@@ -1,4 +1,4 @@
-"Isobaric_label_ions" = {
+{
   "TMT126" : {
     "label_type" : "TMT",
     "ion_type"   : "reporter",


### PR DESCRIPTION
Make sure that the root key in the isobaric labels JSON file is a string.