### PR TITLE
Update auxiliary annotation syntax

### DIFF
--- a/implementations/python/tests/common.py
+++ b/implementations/python/tests/common.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 data_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data"))

--- a/implementations/python/tests/test_annotation.py
+++ b/implementations/python/tests/test_annotation.py
@@ -110,7 +110,7 @@ class TestAnnotationParser(unittest.TestCase):
         assert parsed.confidence == 0.05
         assert parsed == base
 
-        base = '[%s]' % base
+        base = '&%s' % base
         parsed = parse_annotation(base)[0]
         assert parsed.series == 'b'
         assert parsed.position == 14


### PR DESCRIPTION
Update the auxiliary peak annotation syntax, prefixing with `&` instead of enclosing in `[` ... `]`