### PR TITLE
Add Spectronaut TSV backend, refactor implementation details to share some with DIA-NN TSV backend

### DIFF
--- a/implementations/python/mzlib/backends/__init__.py
+++ b/implementations/python/mzlib/backends/__init__.py
@@ -5,4 +5,4 @@ from .bibliospec import BibliospecSpectralLibrary
 from .sptxt import SPTXTSpectralLibrary
 from .diann import DiaNNTSVSpectralLibrary, DIANNTSVSpectralLibrary
 from .spectronaut import SpectronautTSVSpectralLibrary
-from .base import (guess_implementation, SpectralLibraryBackendBase, SpectralLibraryWriterBase)
+from .base import (guess_implementation, SpectralLibraryBackendBase, SpectralLibraryWriterBase, FormatInferenceFailure)

--- a/implementations/python/mzlib/backends/__init__.py
+++ b/implementations/python/mzlib/backends/__init__.py
@@ -3,6 +3,6 @@ from .json import JSONSpectralLibrary, JSONSpectralLibraryWriter
 from .msp import MSPSpectralLibrary
 from .bibliospec import BibliospecSpectralLibrary
 from .sptxt import SPTXTSpectralLibrary
-from .diann import DiaNNTSVSpectralLibrary
+from .diann import DiaNNTSVSpectralLibrary, DIANNTSVSpectralLibrary
 from .spectronaut import SpectronautTSVSpectralLibrary
 from .base import (guess_implementation, SpectralLibraryBackendBase, SpectralLibraryWriterBase)

--- a/implementations/python/mzlib/backends/__init__.py
+++ b/implementations/python/mzlib/backends/__init__.py
@@ -4,4 +4,5 @@ from .msp import MSPSpectralLibrary
 from .bibliospec import BibliospecSpectralLibrary
 from .sptxt import SPTXTSpectralLibrary
 from .diann import DiaNNTSVSpectralLibrary
+from .spectronaut import SpectronautTSVSpectralLibrary
 from .base import (guess_implementation, SpectralLibraryBackendBase, SpectralLibraryWriterBase)

--- a/implementations/python/mzlib/backends/diann.py
+++ b/implementations/python/mzlib/backends/diann.py
@@ -147,7 +147,7 @@ class DIANNTSVSpectralLibrary(_CSVSpectralLibraryBackendBase):
         if "ProteinName" in  descr:
             analyte.add_attribute(
                 "MS:1000886|protein name",
-                descr["Protein Name"],
+                descr["ProteinName"],
                 group_identifier=protein_group_id
             )
 

--- a/implementations/python/mzlib/backends/diann.py
+++ b/implementations/python/mzlib/backends/diann.py
@@ -42,9 +42,7 @@ class DIANNTSVSpectralLibrary(_CSVSpectralLibraryBackendBase):
 
     _custom_spectrum_keys = [
         "ExcludeFromAssay",
-        "BGSInferenceId",
         "AllowForNormalization",
-        "Workflow",
     ]
 
     _custom_analyte_keys = [

--- a/implementations/python/mzlib/backends/diann.py
+++ b/implementations/python/mzlib/backends/diann.py
@@ -16,7 +16,7 @@ def rewrite_unimod_peptide_as_proforma(sequence: str) -> str:
 
 
 CHARGE_STATE = "MS:1000041|charge state"
-SELECTED_ION_MZ = "MS:1000744|selected ion m/z"
+SELECTED_ION_MZ = "MS:1003208|experimental precursor monoisotopic m/z"
 SOURCE_FILE = "MS:1003203|constituent spectrum file"
 STRIPPED_PEPTIDE_TERM = "MS:1000888|stripped peptide sequence"
 PROFORMA_PEPTIDE_TERM = "MS:1003169|proforma peptidoform sequence"

--- a/implementations/python/mzlib/backends/diann.py
+++ b/implementations/python/mzlib/backends/diann.py
@@ -1,17 +1,15 @@
-import csv
-import io
+import json
 
-from typing import List, Tuple, Dict, Iterator, Any
+from typing import List, Tuple, Dict, Iterator, Any, Union
 
-from pyteomics import proforma, mass
+from pyteomics import proforma
 
 from mzlib import annotation
-from mzlib.backends.base import SpectralLibraryBackendBase
-from mzlib.backends.utils import open_stream
+from mzlib.backends.base import DEFAULT_VERSION, FORMAT_VERSION_TERM, _CSVSpectralLibraryBackendBase
 from mzlib.spectrum import Spectrum, SPECTRUM_NAME
 
 
-def rewrite_unimod_peptide_as_proforma(sequence: str) -> str:
+def _rewrite_unimod_peptide_as_proforma(sequence: str) -> str:
     return sequence.replace("(", '[').replace(')', ']').replace("UniMod", "UNIMOD")
 
 
@@ -21,32 +19,52 @@ SOURCE_FILE = "MS:1003203|constituent spectrum file"
 STRIPPED_PEPTIDE_TERM = "MS:1000888|stripped peptide sequence"
 PROFORMA_PEPTIDE_TERM = "MS:1003169|proforma peptidoform sequence"
 
+CUSTOM_ATTRIBUTE_NAME = "MS:1003275|other attribute name"
+CUSTOM_ATTRIBUTE_VALUE = "MS:1003276|other attribute value"
 
-class DiaNNTSVSpectralLibrary(SpectralLibraryBackendBase):
+NO_LOSS = 'noloss'
+
+
+def _parse_value(value: str) -> Union[float, int, str, bool]:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        lower = value.lower()
+        if lower == "true":
+            return True
+        elif lower == "false":
+            return False
+        return value
+
+
+class DIANNTSVSpectralLibrary(_CSVSpectralLibraryBackendBase):
     format_name = "dia-nn.tsv"
 
+    _custom_spectrum_keys = [
+        "ExcludeFromAssay",
+        "BGSInferenceId",
+        "AllowForNormalization",
+        "Workflow",
+    ]
+
+    _custom_analyte_keys = [
+        "Proteotypic",
+        "ProteinGroup",
+    ]
+
     def __init__(self, filename: str, index_type=None, **kwargs):
-        if index_type is None:
-            index_type = self.has_index_preference(filename)
-        super().__init__(filename)
-        self.filename = filename
-        self._headers = None
-        self._read_header_line()
-        self.index, was_initialized = index_type.from_filename(filename)
-        if not was_initialized:
-            self.create_index()
+        super().__init__(filename, index_type=index_type, delimiter='\t')
 
     def _spectrum_type(self):
         key = "MS:1003072|spectrum origin type"
         value = "MS:1003074|predicted spectrum"
         return key, value
 
-    def _read_header_line(self):
-        with open_stream(self.filename) as stream:
-            reader = csv.reader(stream, delimiter='\t')
-            headers = next(reader)
-            stream.seek(0)
-        self._headers = headers
+    def read_header(self) -> bool:
+        result = super().read_header()
+        self.add_attribute(FORMAT_VERSION_TERM, DEFAULT_VERSION)
+        self.add_attribute("MS:1003207|library creation software", "MS:1003253|DIA-NN")
+        return result
 
     def create_index(self):
         with open(self.filename, 'rb') as stream:
@@ -96,9 +114,6 @@ class DiaNNTSVSpectralLibrary(SpectralLibraryBackendBase):
         self.index.commit()
         return n
 
-    def _open_reader(self, stream: io.TextIOBase):
-        return csv.DictReader(stream, fieldnames=self._headers, delimiter='\t')
-
     def _parse_from_buffer(self, buffer: List[Dict[str, Any]], spectrum_index: int = None) -> Spectrum:
         spec = self._new_spectrum()
         descr = buffer[0]
@@ -109,21 +124,54 @@ class DiaNNTSVSpectralLibrary(SpectralLibraryBackendBase):
         spec.add_attribute(SOURCE_FILE, descr['FileName'])
         spec.add_attribute(*self._spectrum_type())
 
+        if int(descr['decoy']):
+            spec.add_attribute("MS:1003072|spectrum origin type", "MS:1003192|decoy spectrum")
+
+        if 'IonMobility' in descr:
+            spec.add_attribute("MS:1002476|ion mobility drift time", float(descr['IonMobility']))
+
         analyte = self._new_analyte('1')
 
-        pf_seq = rewrite_unimod_peptide_as_proforma(descr['FullUniModPeptideName'])
+        pf_seq = _rewrite_unimod_peptide_as_proforma(descr['FullUniModPeptideName'])
         peptide = proforma.ProForma.parse(pf_seq)
 
         analyte.add_attribute(STRIPPED_PEPTIDE_TERM, descr['PeptideSequence'])
         analyte.add_attribute(PROFORMA_PEPTIDE_TERM, pf_seq)
         analyte.add_attribute("MS:1001117|theoretical mass", peptide.mass)
-        analyte.add_attribute("MS:1000885|protein accession", descr['UniprotID'])
+
+        protein_group_id = analyte.get_next_group_identifier()
+        if "UniprotID" in descr:
+            analyte.add_attribute(
+                "MS:1000885|protein accession",
+                descr['UniprotID'],
+                group_identifier=protein_group_id
+            )
+        if "ProteinName" in  descr:
+            analyte.add_attribute(
+                "MS:1000886|protein name",
+                descr["Protein Name"],
+                group_identifier=protein_group_id
+            )
+
+        for key in self._custom_analyte_keys:
+            if key in descr:
+                analyte.add_attribute_group([
+                    [CUSTOM_ATTRIBUTE_NAME, key],
+                    [CUSTOM_ATTRIBUTE_VALUE, _parse_value(descr[key])]
+                ])
 
         spec.add_analyte(analyte)
         spec.peak_list = self._generate_peaks(buffer)
         spec.add_attribute("MS:1003059|number of peaks", len(spec.peak_list))
 
-        if spectrum_index:
+        for key in self._custom_spectrum_keys:
+            if key in descr:
+                spec.add_attribute_group([
+                    [CUSTOM_ATTRIBUTE_NAME, key],
+                    [CUSTOM_ATTRIBUTE_VALUE, _parse_value(descr[key])]
+                ])
+
+        if spectrum_index is not None:
             spec.index = spectrum_index
         else:
             spec.index = -1
@@ -140,8 +188,16 @@ class DiaNNTSVSpectralLibrary(SpectralLibraryBackendBase):
             ordinal = int(row['FragmentSeriesNumber'])
             charge = int(row['FragmentCharge'])
 
+            loss_type = row['FragmentLossType']
+            if loss_type != NO_LOSS:
+                loss_type = ['-' + loss_type]
+            else:
+                loss_type = None
+
             annot = annotation.PeptideFragmentIonAnnotation(
-                series, ordinal, charge=charge, mass_error=annotation.MassError(0, 'Da'))
+                series, ordinal, neutral_losses=loss_type, charge=charge,
+                mass_error=annotation.MassError(0, 'Da')
+            )
 
             peak = [
                 mz, intensity, [annot], []
@@ -149,50 +205,22 @@ class DiaNNTSVSpectralLibrary(SpectralLibraryBackendBase):
             peaks.append(peak)
         return peaks
 
-    def read(self):
-        with open_stream(self.filename) as stream:
-            stream.readline()
-            reader = self._open_reader(stream)
-            batch_iter = batch_rows(reader)
-            for rows in batch_iter:
-                spec = self._parse_from_buffer(rows)
-                yield spec
-
-    def _get_lines_for(self, offset: int) -> List[Dict[str, Any]]:
-        with open_stream(self.filename, 'r') as infile:
-            infile.seek(offset)
-            reader = self._open_reader(infile)
-            spectrum_buffer = next(batch_rows(reader))
-            #### We will end up here if this is the last spectrum in the file
-        return spectrum_buffer
-
-    def get_spectrum(self, spectrum_number: int = None, spectrum_name: str = None) -> Spectrum:
-        # keep the two branches separate for the possibility that this is not possible with all
-        # index schemes.
-        if spectrum_number is not None:
-            if spectrum_name is not None:
-                raise ValueError("Provide only one of spectrum_number or spectrum_name")
-            offset = self.index.offset_for(spectrum_number)
-        elif spectrum_name is not None:
-            offset = self.index.offset_for(spectrum_name)
-        buffer = self._get_lines_for(offset)
-        spectrum = self._parse_from_buffer(buffer, spectrum_number)
-        return spectrum
-
-
-def batch_rows(iterator: Iterator[Dict[str, Any]]) -> Iterator[List[Dict[str, Any]]]:
-    group_key = None
-    group = []
-    for row in iterator:
-        key = row['transition_group_id']
-        if group_key is None:
-            group_key = key
-            group.append(row)
-        elif group_key == key:
-            group.append(row)
-        else:
+    def _batch_rows(self, iterator: Iterator[Dict[str, Any]]) -> Iterator[List[Dict[str, Any]]]:
+        group_key = None
+        group = []
+        for row in iterator:
+            key = row['transition_group_id']
+            if group_key is None:
+                group_key = key
+                group.append(row)
+            elif group_key == key:
+                group.append(row)
+            else:
+                yield group
+                group = [row]
+                group_key = key
+        if group:
             yield group
-            group = [row]
-            group_key = key
-    if group:
-        yield group
+
+
+DiaNNTSVSpectralLibrary = DIANNTSVSpectralLibrary

--- a/implementations/python/mzlib/backends/spectronaut.py
+++ b/implementations/python/mzlib/backends/spectronaut.py
@@ -1,0 +1,268 @@
+import json
+
+from typing import List, Tuple, Dict, Iterator, Any, Deque, Union
+
+from pyteomics import proforma, mass
+
+from mzlib import annotation
+from mzlib.analyte import Analyte
+from mzlib.backends.base import SpectralLibraryBackendBase, _CSVSpectralLibraryBackendBase
+from mzlib.backends.utils import open_stream
+from mzlib.spectrum import Spectrum, SPECTRUM_NAME
+
+
+CHARGE_STATE = "MS:1000041|charge state"
+SELECTED_ION_MZ = "MS:1003208|experimental precursor monoisotopic m/z"
+SOURCE_FILE = "MS:1003203|constituent spectrum file"
+STRIPPED_PEPTIDE_TERM = "MS:1000888|stripped peptide sequence"
+PROFORMA_PEPTIDE_TERM = "MS:1003169|proforma peptidoform sequence"
+
+CUSTOM_ATTRIBUTE_NAME = "MS:1003275|other attribute name"
+CUSTOM_ATTRIBUTE_VALUE = "MS:1003276|other attribute value"
+
+ID_SEP = "/"
+_ID_SEP = ID_SEP.encode("ascii")
+
+NO_LOSS = 'noloss'
+
+
+def _rewrite_modified_peptide_as_proforma(sequence: str) -> str:
+    if sequence.startswith("_"):
+        sequence = sequence.strip("_")
+    buffer: Deque[str] = Deque()
+    last_paren = None
+    for i, c in enumerate(sequence):
+        if c == ']':
+            if last_paren is not None:
+                k = i - last_paren
+                for j in range(k + 1):
+                    buffer.pop()
+                last_paren = None
+                buffer.append(c)
+        elif c == '(':
+            last_paren = i
+            buffer.append(c)
+        else:
+            buffer.append(c)
+    return ''.join(buffer)
+
+
+def _parse_value(value: str) -> Union[float, int, str, bool]:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        lower = value.lower()
+        if lower == "true":
+            return True
+        elif lower == "false":
+            return False
+        return value
+
+
+class SpectronautTSVSpectralLibrary(_CSVSpectralLibraryBackendBase):
+    format_name = "spectronaut.tsv"
+
+    _custom_spectrum_keys = [
+        "ExcludeFromAssay",
+        "BGSInferenceId",
+        "AllowForNormalization",
+        "Workflow",
+    ]
+
+    _custom_analyte_keys = [
+        "IsProteotypic",
+        "FASTAName",
+        "Database",
+        "ProteinGroups",
+    ]
+
+    def __init__(self, filename: str, index_type=None, **kwargs):
+        super().__init__(filename, index_type=index_type, delimiter='\t', **kwargs)
+
+    def _spectrum_type(self):
+        key = "MS:1003072|spectrum origin type"
+        value = "MS:1003074|predicted spectrum"
+        return key, value
+
+    def _batch_rows(self, iterator: Iterator[Dict[str, Any]]) -> Iterator[List[Dict[str, Any]]]:
+        group_key = None
+        group = []
+        for row in iterator:
+            key = (row['ModifiedPeptide'], row['PrecursorCharge'], )
+            if group_key is None:
+                group_key = key
+                group.append(row)
+            elif group_key == key:
+                group.append(row)
+            else:
+                yield group
+                group = [row]
+                group_key = key
+        if group:
+            yield group
+
+    def create_index(self):
+        key = None
+        with open_stream(self.filename, 'rb') as stream:
+            header = stream.readline()
+            header_cols = header.split(b'\t')
+            column_keys = (
+                header_cols.index(b'ModifiedPeptide'),
+                header_cols.index(b'PrecursorCharge'),
+            )
+            offset = stream.tell()
+
+            line = stream.readline()
+            tokens = line.split(b'\t')
+            key = (tokens[column_keys[0]].strip(b"_"), tokens[column_keys[1]])
+            n = 0
+            self.index.add(
+                number=n,
+                offset=offset,
+                name=_ID_SEP.join(key).decode("utf8"),
+                analyte=None
+            )
+            n += 1
+
+            # To hold previous values
+            last_offset = None
+            while line:
+                tokens = line.split(b'\t')
+                next_key = (tokens[column_keys[0]].strip(b"_"), tokens[column_keys[1]])
+                if next_key != key:
+                    key = next_key
+                    self.index.add(
+                        number=n,
+                        offset=offset,
+                        name=_ID_SEP.join(key).decode("utf8"),
+                        analyte=None
+                    )
+                    n += 1
+                    last_offset = stream.tell()
+                else:
+                    offset = stream.tell()
+                line = stream.readline()
+
+        if key is not None:
+            self.index.add(
+                number=n,
+                offset=last_offset,
+                name=_ID_SEP.join(key).decode('utf8'),
+                analyte=None
+            )
+        n += 1
+        self.index.commit()
+        return n
+
+    def _generate_peaks(self, batch: List[Dict[str, Any]]) -> List[Tuple[float, float, List[annotation.IonAnnotationBase], List]]:
+        peaks = []
+        for row in batch:
+            mz = float(row['FragmentMz'])
+            intensity = float(row['RelativeIntensity'])
+
+            series = row['FragmentType']
+            ordinal = int(row['FragmentNumber'])
+            charge = int(row['FragmentCharge'])
+
+            loss_type = row['FragmentLossType']
+            if loss_type != NO_LOSS:
+                loss_type = ['-' + loss_type]
+            else:
+                loss_type = None
+
+            annot = annotation.PeptideFragmentIonAnnotation(
+                series, ordinal, neutral_losses=loss_type, charge=charge,
+                mass_error=annotation.MassError(0, 'Da')
+            )
+
+            peak = [
+                mz, intensity, [annot], []
+            ]
+            peaks.append(peak)
+        return peaks
+
+    def _build_analyte(self, description: Dict[str, Any], analyte: Analyte) -> Analyte:
+        pf_seq = _rewrite_modified_peptide_as_proforma(description['ModifiedPeptide'])
+        peptide = proforma.ProForma.parse(pf_seq)
+
+        analyte.add_attribute(STRIPPED_PEPTIDE_TERM, description['StrippedPeptide'])
+        analyte.add_attribute(PROFORMA_PEPTIDE_TERM, pf_seq)
+        analyte.add_attribute("MS:1001117|theoretical mass", peptide.mass)
+
+        protein_group_id = analyte.get_next_group_identifier()
+
+        analyte.add_attribute(
+            "MS:1000885|protein accession",
+            description['UniProtIds'],
+            group_identifier=protein_group_id
+        )
+        analyte.add_attribute(
+            "MS:1000886|protein name",
+            description["Protein Name"],
+            group_identifier=protein_group_id
+        )
+        analyte.add_attribute(
+            "MS:1001088|protein description",
+            description['ProteinDescription'],
+            group_identifier=protein_group_id
+        )
+
+        if "OrganismId" in description:
+            analyte.add_attribute_group([
+                ["MS:1001467|taxonomy: NCBI TaxID", f"NCBITaxon:{description['OrganismId']}|{description['Organisms']}"],
+                ["MS:1001469|taxonomy: scientific name", description['Organisms']],
+            ])
+
+        for key in self._custom_analyte_keys:
+            if key in description:
+                analyte.add_attribute_group([
+                    [CUSTOM_ATTRIBUTE_NAME, key],
+                    [CUSTOM_ATTRIBUTE_VALUE, _parse_value(description[key])]
+                ])
+
+        return analyte
+
+    def _parse_from_buffer(self, buffer: List[Dict[str, Any]], spectrum_index: int = None) -> Spectrum:
+        spec = self._new_spectrum()
+        descr = buffer[0]
+
+        key = (descr['ModifiedPeptide'].strip("_"), descr['PrecursorCharge'])
+
+        spec.add_attribute(SPECTRUM_NAME, ID_SEP.join(key))
+        spec.add_attribute(SELECTED_ION_MZ, float(descr['PrecursorMz']))
+        spec.add_attribute(CHARGE_STATE, int(descr['PrecursorCharge']))
+        spec.add_attribute(SOURCE_FILE, descr['ReferenceRun'])
+        spec.add_attribute(*self._spectrum_type())
+
+        spec.add_attribute_group([
+            [CUSTOM_ATTRIBUTE_NAME, "LabeledPeptide"],
+            [CUSTOM_ATTRIBUTE_VALUE, descr['LabeledPeptide']]
+        ])
+
+        if 'IonMobility' in descr:
+            spec.add_attribute("MS:1002476|ion mobility drift time", float(descr['IonMobility']))
+        if 'CV' in descr:
+            spec.add_attribute("MS:1001581|FAIMS compensation voltage", float(descr['CV']))
+        if 'iRT' in descr:
+            spec.add_attribute("MS:1000896|normalized retention time", float(descr['iRT']))
+
+        analyte = self._new_analyte('1')
+        self._build_analyte(descr, analyte)
+        spec.add_analyte(analyte)
+
+        for key in self._custom_spectrum_keys:
+            if key in descr:
+                spec.add_attribute_group([
+                    [CUSTOM_ATTRIBUTE_NAME, key],
+                    [CUSTOM_ATTRIBUTE_VALUE, _parse_value(descr[key])]
+                ])
+
+        spec.peak_list = self._generate_peaks(buffer)
+        spec.add_attribute("MS:1003059|number of peaks", len(spec.peak_list))
+
+        if spectrum_index:
+            spec.index = spectrum_index
+        else:
+            spec.index = -1
+        spec.key = spec.index + 1
+        return spec

--- a/implementations/python/mzlib/draw.py
+++ b/implementations/python/mzlib/draw.py
@@ -56,7 +56,8 @@ def peaklist_to_vector(peaklist, width=0.000001):
 
 
 def draw_spectrum(spectrum, ax=None, normalize=False, label_threshold=0.1, label_rotation=0, **kwargs):
-    """Draw and annotate a Spectrum.
+    """
+    Draw and annotate a Spectrum.
 
     Parameters
     ----------
@@ -70,7 +71,9 @@ def draw_spectrum(spectrum, ax=None, normalize=False, label_threshold=0.1, label
     pretty: bool, optional
         If `True`, will call :func:`_beautify_axes` on `ax`
     label_threshold: float, optional
-        The minimum
+        The minimum intensity to label a peak for
+    label_rotation : float, optional
+        The degrees of rotation to apply to peak labels
     **kwargs
         Passed to :meth:`matplotlib.Axes.plot`
     Returns

--- a/implementations/python/mzlib/index/sql.py
+++ b/implementations/python/mzlib/index/sql.py
@@ -4,7 +4,10 @@ import pathlib
 import logging
 
 from sqlalchemy import Column, ForeignKey, Integer, Float, String, DateTime, Text, LargeBinary
-from sqlalchemy.ext.declarative import declarative_base
+try: # For SQLAlchemy 2.0
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker

--- a/implementations/python/mzlib/spectrum_library.py
+++ b/implementations/python/mzlib/spectrum_library.py
@@ -77,7 +77,10 @@ class SpectrumLibrary:
             self.backend = guess_implementation(self.filename, index_type)
             self._format = self.backend.format_name
         else:
-            backend_type = SpectralLibraryBackendBase.type_for_format(self.format)
+            if callable(self.format):
+                backend_type = self.format
+            else:
+                backend_type = SpectralLibraryBackendBase.type_for_format(self.format)
             if backend_type is None:
                 raise ValueError(
                     f"Could not find an implementation for {self.format}")


### PR DESCRIPTION
This PR implements a new backend for the Spectronaut TSV library format. It refactored the DIA-NN TSV backend so they share a lot of common plumbing.

I've also tried to forward more tool-specific columns just in case they are useful. I suspect that there's still a lot missing that has to do with how these tools do protein inference. I think there are terms for this under `MS:1001085` or `MS:1001101`, but I'm not familiar with where these terms are used in extant PSI formats.  

Another consequence is that we cannot safely infer these TSV file formats from reading the first couple of lines of the file, nor do they have informative names or file extensions, so I've made the tooling fail with a more informative warning message. I considered trying to identify distinctive columns, but this didn't feel "future-proof" and given that I've use neither tool in practice, I opted to make the user do the work.

