### PR TITLE
Add guidelines section to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the developers of spectral library search tools and resources.
   - [Introduction](#introduction)
   - [Development](#development)
   - [Reference implementation](#reference-implementation)
+  - [Guidelines](#guidelines)
   - [Contributing](#contributing)
 
 ---
@@ -69,6 +70,9 @@ A reference implementation of the mzSpecLib format is available in the form of a
 Check out the [mzspeclib-py](https://github.com/HUPO-PSI/mzspeclib-py) repository or the
 [Python package documentation](https://mzspeclib.readthedocs.io/) for more information.
 
+## Guidelines
+
+The mzSpecLib format is flexible, but we have examples showing how to use it in certain ways in
 
 ## Contributing
 

--- a/docs/guidelines/index.rst
+++ b/docs/guidelines/index.rst
@@ -1,0 +1,8 @@
+Guidelines
+----------
+
+.. toctree::
+   :caption: Guidelines
+
+   mz_terms
+   mass_terms

--- a/docs/guidelines/mass_terms.csv
+++ b/docs/guidelines/mass_terms.csv
@@ -1,0 +1,4 @@
+Term,Intended Use
+``MS:1000224|molecular mass``,"Describes the neutral mass of the molecule being measured without the charge carriers"
+``MS:1003243|adduct ion mass``,"Describes the neutral mass of the molecule *plus* the mass of the charge carrier(s)"
+``MS:1001117|theoretical neutral mass``,"Describes the neutral mass of the molecule without the charge carriers calculated directly from the molecule identity"

--- a/docs/guidelines/mass_terms.rst
+++ b/docs/guidelines/mass_terms.rst
@@ -1,0 +1,11 @@
+Specifying Ion Mass
+-------------------
+
+.. csv-table:: Mass Controlled Vocabulary Terms
+   :file: mass_terms.csv
+   :widths: 30, 70
+   :header-rows: 1
+   :name: ion mass terms
+
+
+TODO

--- a/docs/guidelines/mz_terms.csv
+++ b/docs/guidelines/mz_terms.csv
@@ -1,0 +1,4 @@
+Term,Intended Use
+``MS:1000744|selected ion m/z``,"The selected precursor ion as reported by the instrument for isolation. Should be used for a `Spectrum`"
+``MS:|experimentally determined monoisotopic m/z``,"The monoisotopic peak of the selected ion as determined by the implementation. Usually used for a `Spectrum`, but for chimeric or ambiguous spectra may also be used in an `Interpretation` or `InterpretationMember`"
+``MS:1003053|theoretical monoisotopic m/z``,"The theoretical m/z for an ion calculated by the implementation. Should be used for an `Analyte`"

--- a/docs/guidelines/mz_terms.rst
+++ b/docs/guidelines/mz_terms.rst
@@ -1,0 +1,31 @@
+Specifying ion m/z
+------------------
+
+.. csv-table:: M/Z Controlled Vocabulary Terms
+   :file: mz_terms.csv
+   :widths: 30, 70
+   :header-rows: 1
+   :name: m/z terms
+
+Selected Ion M/Z
+================
+
+The :title-reference:`selected ion m/z` term is intended to be used in
+:title-reference:`mzSpecLib` in the same manner as in :title-reference:`mzML`.
+It reflects the assumption that this value is not refined by some other
+method that the implementation used, and carries with it the same uncertainty.
+Because it is not directly related to an `Analyte`'s identity, this attribute
+belongs to the `Spectrum` alone.
+
+Experimentally Determined Monoisotopic M/Z
+==========================================
+
+The :title-reference:`experimentally determined monoisotopic m/z` term
+was created for :title-reference:`mzSpecLib` to indicate that this m/z
+value was refined in some way by the implementation. This implies that
+the value is expected to be *correct* in-so-far as the implementation
+can tell.
+
+Because the determination might be done with information about
+an `Analyte`, this attribute could appear under either the `Spectrum` or
+the `Interpretation` or `InterpretationMember` sections.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,3 +10,4 @@
    Home <self>
    specification/index
    contributing
+   guidelines/index

--- a/specification/README.md
+++ b/specification/README.md
@@ -5,4 +5,4 @@ The mzSpecLib specification is nearly complete and has been resubmitted to the P
 If you do experience problems with the files or have suggestions or comments, please open an [issue](https://github.com/HUPO-PSI/mzSpecLib/issues).
 
 - [mzSpecLib main specification document](https://github.com/HUPO-PSI/mzSpecLib/blob/master/specification/mzSpecLib_specification_v1.0_draft09.docx)
-- [mzPAF peak interetation format](https://psidev.info/mzPAF)
+- [mzPAF peak interpretation format](https://psidev.info/mzPAF)


### PR DESCRIPTION
This adds the guidelines section to the documentation website, and stubs for two guideline sections on ion m/z and mass terms. 

In writing this out I couldn't discriminate a difference _in intent_ for `theoretical neutral mass` vs. `molecular mass`. @henryhlam do you have an opinion on what is appropriate here, or should we instead say something along the lines of "always use `theoretical neutral mass` where possible to avoid ambiguity" or vice-versa?