### PR TITLE
Update mass_terms.rst

### DIFF
--- a/docs/guidelines/mass_terms.rst
+++ b/docs/guidelines/mass_terms.rst
@@ -8,4 +8,21 @@ Specifying Ion Mass
    :name: ion mass terms
 
 
-TODO
+Molecular Mass
+==============
+
+The :title-reference:`molecular mass` term is a generic term used to describe the mass of a molecule in Da. It is too vague to be used in the context of MS. Its use in
+:title-reference:`mzSpecLib` is discouraged.
+
+
+Adduct Ion Mass
+==============
+
+The :title-reference:`adduct ion mass` term refers to the mass of the adduct ion which fragments to yield that library spectrum. The mass should include both the neutral analyte and the charge-carrying moeity. It is expected that this value is calculated from summing the *monoisotopic* masses of the constituent atoms/ions, and as such, should be listed under the `Analyte` section. 
+
+
+Theoretical Neutral Mass
+========================
+
+The :title-reference:`theoretical neutral mass` term refers to the mass of the neutral analyte. It does not include the charge-carrying moeity. It is expected that this value is calculated from summing the *monoisotopic* masses of the constituent atoms, and as such, should be listed under the `Analyte` section.
+

--- a/docs/guidelines/mass_terms.rst
+++ b/docs/guidelines/mass_terms.rst
@@ -11,18 +11,40 @@ Specifying Ion Mass
 Molecular Mass
 ==============
 
-The :title-reference:`molecular mass` term is a generic term used to describe the mass of a molecule in Da. It is too vague to be used in the context of MS. Its use in
-:title-reference:`mzSpecLib` is discouraged.
+The :title-reference:`molecular mass` term is a generic term used to describe the mass of a molecule in Da. While in typical use it refers to the average mass based on the natural isotope abundances, the term is too vague to be used in the context of MS. Its use in :title-reference:`mzSpecLib` is discouraged in favor of the more explicit term :title-reference:`theroetical neutral average mass`. 
 
 
 Adduct Ion Mass
-==============
+===============
 
-The :title-reference:`adduct ion mass` term refers to the mass of the adduct ion which fragments to yield that library spectrum. The mass should include both the neutral analyte and the charge-carrying moeity. It is expected that this value is calculated from summing the *monoisotopic* masses of the constituent atoms/ions, and as such, should be listed under the `Analyte` section. 
+The :title-reference:`adduct ion mass` term refers to the mass of the adduct ion which fragments to yield that library spectrum. The mass should include both the neutral analyte and the charge-carrying moeity. However, it does not specify whether it is the monoisotopic mass or the average mass. For clarity, :title-reference:`adduct ion monoisotopic mass` and :title-reference:`adduct ion average mass` should be used instead. 
 
+Adduct Ion Monoisotoptic Mass
+=============================
+
+The :title-reference:`adduct ion monoisotopic mass` term refers to the *monoisotopic* mass of the adduct ion which fragments to yield that library spectrum. The mass should include both the neutral analyte and the charge-carrying moeity. This value should be calculated from summing the monoisotopic masses of the constituent atoms/ions, and as such, should be listed under the `Analyte` section.
+
+
+Adduct Ion Average Mass
+=======================
+
+The :title-reference:`adduct ion average mass` term refers to the *average* mass of the adduct ion which fragments to yield that library spectrum. The mass should include both the neutral analyte and the charge-carrying moeity. This value should be calculated from summing the average masses of the constituent atoms/ions, and as such, should be listed under the `Analyte` section.
 
 Theoretical Neutral Mass
 ========================
 
-The :title-reference:`theoretical neutral mass` term refers to the mass of the neutral analyte. It does not include the charge-carrying moeity. It is expected that this value is calculated from summing the *monoisotopic* masses of the constituent atoms, and as such, should be listed under the `Analyte` section.
+The :title-reference:`theoretical neutral mass` term refers to the mass of the neutral analyte. It does not include the charge-carrying moeity. However, it does not specify whether it is the monoisotopic mass or the average mass. For clarity, :title-reference:`theoretical neutral monoisotopic mass` and :title-reference:`theoretical neutral average mass` should be used instead. 
+
+Theoretical Neutral Monoisotopic Mass
+=====================================
+
+The :title-reference:`theoretical neutral monoisotopic mass` term refers to the *monoisotopic* mass of the neutral analyte. It does not include the charge-carrying moeity. This value should be calculated from summing the monoisotopic masses of the constituent atoms, and as such, should be listed under the `Analyte` section.
+
+Theoretical Neutral Average Mass
+================================
+
+The :title-reference:`theoretical neutral average mass` term refers to the *average* mass of the neutral analyte. It does not include the charge-carrying moeity. This value should be calculated from summing the average masses of the constituent atoms, and as such, should be listed under the `Analyte` section.
+
+
+
 


### PR DESCRIPTION
Trying to clarify the usage of the mass terms in mzSpecLib. Some observations:

- We do not have terms for "experimental" precursor masses (but we have those for m/z). Obviously the MS measures m/z, not mass directly, so it may not be necessary. But some tools may calculate an "experimental" precursor mass from the experimental precursor m/z together with a determined charge state. And some tools may want to report a precursor mass deviation (i.e. experimental mass - theoretical mass) in the Interpretation section, which we also don't have a term for. (We only have m/z deviation terms.)

- I noticed that the QC folks have defined a few terms like: "MS_4000178|precursor ppm deviation mean" whose definition is: "the mean of the distribution of observed precursor mass accuracies ([observed mass accuracy) [in ppm] of identified MS2 spectra after user-defined acceptance criteria (FDR) are applied."  Here, the "mass" deviation (which I guess is what it meant by "mass accuracy" distribution) probably should have been "m/z" deviation. I guess we won't use it in mzSpecLib but it may be a source of confusion.
 
- We also have not been clear about isotopes. The "theoretical neutral mass" can still be ambiguous because it can be (i) the mass of the monoisotope (which is what we typically calculate) of the analyte, (ii) the average mass (calculated based on natural isotope abundance) of the analyte, or (iii) the mass of one particular isotope that is being fragmented to yield the spectrum. For now, I stated that we meant (i) the monoisotopic mass, but it was not in the term definition.

- On (ii), the average mass of an analyte is often referred to the "molecular mass" (MW) by chemists. We don't have the term "average mass" and the term definition of "molecular mass" also doesn't say that it means the average mass.    

-  On (iii), there may be a use case that the MS selects one particular isotope to fragment. I don't know if I have seen a library spectrum like that yet.
     
